### PR TITLE
fix: Correct WireGuard dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
-    implementation(libs.wireguard.android.tunnel)
+    implementation(libs.wireguard.android.library)
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test) // Added kotlinx-coroutines-test
     androidTestImplementation(libs.androidx.junit)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,8 +8,8 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.8.0"
 composeBom = "2024.09.00"
-wireguardTunnel = "1.0.20210218"
 kotlinxCoroutinesTest = "1.8.0"
+wireguardAndroidLib = "0.5.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -26,8 +26,8 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-wireguard-android-tunnel = { group = "com.wireguard.android", name = "tunnel", version.ref = "wireguardTunnel" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+wireguard-android-library = { group = "com.wireguard.android", name = "wireguard-android-library", version.ref = "wireguardAndroidLib" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Replaces the previously incorrect WireGuard tunnel dependency with the correct and resolvable `com.wireguard.android:wireguard-android-library:0.5.3`.

The previous dependency `com.wireguard.android:tunnel:1.0.20210218` was not found in standard repositories (Google Maven, Maven Central), leading to build failures.

This commit:
- Removes the incorrect `wireguard-android-tunnel` from `gradle/libs.versions.toml` and `app/build.gradle.kts`.
- Adds the `wireguard-android-library` version `0.5.3` to `gradle/libs.versions.toml`.
- Adds the corresponding implementation dependency to `app/build.gradle.kts`.
- Verifies that `mavenCentral()` is present in `settings.gradle.kts` to ensure the new dependency can be resolved.

This change should allow your project to build successfully.