### PR TITLE
fix: Use JitPack for WireGuard dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
-    implementation(libs.wireguard.android.library)
+    implementation(libs.wireguard.android.jitpack)
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test) // Added kotlinx-coroutines-test
     androidTestImplementation(libs.androidx.junit)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.8.0"
 composeBom = "2024.09.00"
 kotlinxCoroutinesTest = "1.8.0"
-wireguardAndroidLib = "0.5.3"
+wireguardJitpack = "0.5.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -27,7 +27,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
-wireguard-android-library = { group = "com.wireguard.android", name = "wireguard-android-library", version.ref = "wireguardAndroidLib" }
+wireguard-android-jitpack = { group = "com.github.WireGuard", name = "wireguard-android", version.ref = "wireguardJitpack" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = uri("https://jitpack.io") }
     }
 }
 


### PR DESCRIPTION
Updates the project to use JitPack for resolving the WireGuard Android library. This is an attempt to fix persistent build issues related to finding the WireGuard dependency in Maven Central or Google Maven.

This commit:
- Removes previous attempts to add WireGuard dependencies.
- Adds `maven { url = uri("https://jitpack.io") }` to `settings.gradle.kts`.
- Adds the WireGuard dependency as `com.github.WireGuard:wireguard-android:0.5.3` in `gradle/libs.versions.toml` and `app/build.gradle.kts`.

This approach should allow Gradle to fetch and build the WireGuard library directly from its GitHub repository via JitPack.