### PR TITLE
fix: Use specific module GAV for WireGuard JitPack dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
-    implementation(libs.wireguard.android.jitpack)
+    implementation(libs.wireguard.android.jitpack.library)
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test) // Added kotlinx-coroutines-test
     androidTestImplementation(libs.androidx.junit)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.8.0"
 composeBom = "2024.09.00"
 kotlinxCoroutinesTest = "1.8.0"
-wireguardJitpack = "0.5.3"
+wireguardJitpackVersion = "0.5.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -27,7 +27,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
-wireguard-android-jitpack = { group = "com.github.WireGuard", name = "wireguard-android", version.ref = "wireguardJitpack" }
+wireguard-android-jitpack-library = { group = "com.github.WireGuard.wireguard-android", name = "wireguard-android-library", version.ref = "wireguardJitpackVersion" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Updates the project to use a more specific JitPack GAV for resolving the WireGuard Android library, pointing directly to the `wireguard-android-library` module.

This commit:
- Removes previous JitPack GAV for WireGuard.
- Updates `gradle/libs.versions.toml` and `app/build.gradle.kts` to use `com.github.WireGuard.wireguard-android:wireguard-android-library:0.5.3`.

This more precise GAV should help JitPack correctly locate and build the intended library module from the `WireGuard/wireguard-android` repository.