### PR TITLE
fix: Use alternative WireGuard library from Maven Central

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
-    implementation(libs.wireguard.android.jitpack.library)
+    implementation(libs.wireguard.android.fgribreau)
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test) // Added kotlinx-coroutines-test
     androidTestImplementation(libs.androidx.junit)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.8.0"
 composeBom = "2024.09.00"
 kotlinxCoroutinesTest = "1.8.0"
-wireguardJitpackVersion = "0.5.3"
+fgribreauWireguard = "1.0.10"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -27,7 +27,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
-wireguard-android-jitpack-library = { group = "com.github.WireGuard.wireguard-android", name = "wireguard-android-library", version.ref = "wireguardJitpackVersion" }
+wireguard-android-fgribreau = { group = "io.github.FGRibreau.wireguard-android", name = "wireguard-android", version.ref = "fgribreauWireguard" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Replaces previous WireGuard dependency attempts with `io.github.FGRibreau.wireguard-android:wireguard-android:1.0.10`.

Previous attempts to use artifacts from `com.wireguard.android` (via Maven Central) and `com.github.WireGuard` (via JitPack) failed to resolve.

This commit:
- Removes any prior WireGuard dependencies.
- Adds `io.github.FGRibreau.wireguard-android:wireguard-android:1.0.10` to `gradle/libs.versions.toml` and `app/build.gradle.kts`.
- This library is available on Maven Central and should resolve correctly.

This change aims to establish a working WireGuard library dependency to allow your project to build and proceed with VPN feature implementation.