### PR TITLE
Here's a summary of the changes I've made:

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
-wireguard-android-fgribreau = { group = "io.github.FGRibreau.wireguard-android", name = "wireguard-android", version.ref = "fgribreauWireguard" }
+wireguard-android-fgribreau = { group = "io.github.fgribreau.wireguard-android", name = "wireguard-android", version.ref = "fgribreauWireguard" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
I've corrected the group ID casing for the WireGuard dependency in your project. It now uses the correct lowercase group ID for `io.github.fgribreau.wireguard-android:wireguard-android:1.0.10`.

Previously, attempts to resolve this artifact may have failed due to incorrect casing in the group ID (`FGRibreau` instead of `fgribreau`), as Maven repositories are case-sensitive. This was causing Gradle to fail to find it on Maven Central and then incorrectly attempt JitPack, resulting in a 401 error.

Specifically, I have:
- Removed the WireGuard dependency with the incorrect group ID casing.
- Added `io.github.fgribreau.wireguard-android:wireguard-android:1.0.10` to `gradle/libs.versions.toml` and `app/build.gradle.kts` with the correct `io.github.fgribreau.wireguard-android` group ID.

This change should allow Gradle to correctly resolve the dependency from Maven Central.