### PR TITLE
diag: Add OkHttp dependency for testing Maven Central resolution

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     implementation(libs.wireguard.android.fgribreau)
+    implementation(libs.squareup.okhttp)
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test) // Added kotlinx-coroutines-test
     androidTestImplementation(libs.androidx.junit)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ activityCompose = "1.8.0"
 composeBom = "2024.09.00"
 kotlinxCoroutinesTest = "1.8.0"
 fgribreauWireguard = "1.0.10"
+squareupOkhttp = "4.9.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -28,6 +29,7 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 wireguard-android-fgribreau = { group = "io.github.fgribreau.wireguard-android", name = "wireguard-android", version.ref = "fgribreauWireguard" }
+squareup-okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "squareupOkhttp" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Adds `com.squareup.okhttp3:okhttp:4.9.3` as a temporary dependency. The purpose of this commit is to diagnose issues with Gradle dependency resolution, specifically to check if artifacts from Maven Central are being resolved correctly.

The previously added WireGuard dependency (`io.github.fgribreau.wireguard-android`) is kept in place to observe its behavior in conjunction with this test.

If OkHttp resolves successfully, it indicates that Maven Central is generally accessible, and the problem is more specific to the WireGuard libraries tried. If OkHttp also fails to resolve from Maven Central and Gradle attempts to fetch it from JitPack or another source, it would suggest a more fundamental issue with the Gradle repository configuration or network access to Maven Central.